### PR TITLE
Fix deadlock.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -214,7 +214,7 @@ func (s *cachingStore) GroupByName(name string) (*accounts.Group, error) {
 	}
 	ch := make(chan struct{})
 	logger.Info("Triggering refresh due to missing group.")
-	s.updateWaiters <- ch
+	go func() { s.updateWaiters <- ch }()
 	// Do not block on update.
 	return nil, accounts.GroupNameNotFound(name)
 }


### PR DESCRIPTION
This deadlock happens when GroupByName is holding an RLock, while
blocking on a push to the updateWaiters channel. This channel is
serviced by the update goroutine which may be blocked trying to acquire
a Lock. Solution, do not block on the channel push.
